### PR TITLE
fix 1.15.3+ patch

### DIFF
--- a/nginx__dynamic_tls_records_1.15.3+.patch
+++ b/nginx__dynamic_tls_records_1.15.3+.patch
@@ -27,18 +27,18 @@ https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__dynamic_tls_r
 
 --- a/src/event/ngx_event_openssl.c
 +++ b/src/event/ngx_event_openssl.c
-@@ -1131,6 +1131,7 @@
-
+@@ -1267,6 +1267,7 @@ ngx_ssl_create_connection(ngx_ssl_t *ssl, ngx_connection_t *c, ngx_uint_t flags)
+ 
      sc->buffer = ((flags & NGX_SSL_BUFFER) != 0);
      sc->buffer_size = ssl->buffer_size;
 +    sc->dyn_rec = ssl->dyn_rec;
-
+ 
      sc->session_ctx = ssl->ctx;
-
-@@ -1669,6 +1670,41 @@
-
+ 
+@@ -2115,6 +2116,41 @@ ngx_ssl_send_chain(ngx_connection_t *c, ngx_chain_t *in, off_t limit)
+ 
      for ( ;; ) {
-
+ 
 +        /* Dynamic record resizing:
 +           We want the initial records to fit into one TCP segment
 +           so we don't get TCP HoL blocking due to TCP Slow Start.
@@ -77,22 +77,22 @@ https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__dynamic_tls_r
          while (in && buf->last < buf->end && send < limit) {
              if (in->buf->last_buf || in->buf->flush) {
                  flush = 1;
-@@ -1770,6 +1806,9 @@
-
+@@ -2222,6 +2258,9 @@ ngx_ssl_write(ngx_connection_t *c, u_char *data, size_t size)
+ 
      if (n > 0) {
-
+ 
 +        c->ssl->dyn_rec_records_sent++;
 +        c->ssl->dyn_rec_last_write = ngx_current_msec;
 +
          if (c->ssl->saved_read_handler) {
-
+ 
              c->read->handler = c->ssl->saved_read_handler;
 --- a/src/event/ngx_event_openssl.h
 +++ b/src/event/ngx_event_openssl.h
 @@ -64,10 +64,19 @@
  #endif
-
-
+ 
+ 
 +typedef struct {
 +    ngx_msec_t                  timeout;
 +    ngx_uint_t                  threshold;
@@ -107,9 +107,9 @@ https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__dynamic_tls_r
      size_t                      buffer_size;
 +    ngx_ssl_dyn_rec_t           dyn_rec;
  };
-
-
-@@ -95,6 +104,11 @@
+ 
+ 
+@@ -95,6 +104,11 @@ struct ngx_ssl_connection_s {
      unsigned                    no_wait_shutdown:1;
      unsigned                    no_send_shutdown:1;
      unsigned                    handshake_buffer_set:1;
@@ -121,21 +121,21 @@ https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__dynamic_tls_r
      unsigned                    try_early_data:1;
      unsigned                    in_early:1;
      unsigned                    early_preread:1;
-@@ -107,7 +121,7 @@
+@@ -107,7 +121,7 @@ struct ngx_ssl_connection_s {
  #define NGX_SSL_DFLT_BUILTIN_SCACHE  -5
-
-
+ 
+ 
 -#define NGX_SSL_MAX_SESSION_SIZE  4096
 +#define NGX_SSL_MAX_SESSION_SIZE  16384
-
+ 
  typedef struct ngx_ssl_sess_id_s  ngx_ssl_sess_id_t;
-
+ 
 --- a/src/http/modules/ngx_http_ssl_module.c
 +++ b/src/http/modules/ngx_http_ssl_module.c
-@@ -233,6 +233,41 @@
-       offsetof(ngx_http_ssl_srv_conf_t, stapling_verify),
+@@ -246,6 +246,41 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
+       offsetof(ngx_http_ssl_srv_conf_t, early_data),
        NULL },
-
+ 
 +    { ngx_string("ssl_dyn_rec_enable"),
 +      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
 +      ngx_conf_set_flag_slot,
@@ -173,8 +173,8 @@ https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__dynamic_tls_r
 +
        ngx_null_command
  };
-
-@@ -533,6 +568,11 @@
+ 
+@@ -576,6 +611,11 @@ ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
      sscf->session_ticket_keys = NGX_CONF_UNSET_PTR;
      sscf->stapling = NGX_CONF_UNSET;
      sscf->stapling_verify = NGX_CONF_UNSET;
@@ -183,13 +183,13 @@ https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__dynamic_tls_r
 +    sscf->dyn_rec_size_lo = NGX_CONF_UNSET_SIZE;
 +    sscf->dyn_rec_size_hi = NGX_CONF_UNSET_SIZE;
 +    sscf->dyn_rec_threshold = NGX_CONF_UNSET_UINT;
-
+ 
      return sscf;
  }
-@@ -598,6 +638,20 @@
+@@ -643,6 +683,20 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
      ngx_conf_merge_str_value(conf->stapling_responder,
                           prev->stapling_responder, "");
-
+ 
 +    ngx_conf_merge_value(conf->dyn_rec_enable, prev->dyn_rec_enable, 0);
 +    ngx_conf_merge_msec_value(conf->dyn_rec_timeout, prev->dyn_rec_timeout,
 +                             1000);
@@ -205,12 +205,12 @@ https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__dynamic_tls_r
 +                             40);
 +
      conf->ssl.log = cf->log;
-
+ 
      if (conf->enable) {
-@@ -778,6 +832,28 @@
-
+@@ -827,6 +881,28 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+         return NGX_CONF_ERROR;
      }
-
+ 
 +    if (conf->dyn_rec_enable) {
 +        conf->ssl.dyn_rec.timeout = conf->dyn_rec_timeout;
 +        conf->ssl.dyn_rec.threshold = conf->dyn_rec_threshold;
@@ -235,11 +235,11 @@ https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__dynamic_tls_r
 +
      return NGX_CONF_OK;
  }
-
+ 
 --- a/src/http/modules/ngx_http_ssl_module.h
 +++ b/src/http/modules/ngx_http_ssl_module.h
-@@ -57,6 +57,12 @@
-
+@@ -58,6 +58,12 @@ typedef struct {
+ 
      u_char                         *file;
      ngx_uint_t                      line;
 +
@@ -249,4 +249,5 @@ https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__dynamic_tls_r
 +    size_t                          dyn_rec_size_hi;
 +    ngx_uint_t                      dyn_rec_threshold;
  } ngx_http_ssl_srv_conf_t;
-
+ 
+ 


### PR DESCRIPTION
The `git apply` always gave me `fatal: corrupt patch at line` so I'm not sure if it is really the update from 1.15.3 to 1.15.5 or actually a corrupt patch file.

Even your DockerHub failed with 1.15.3:
https://hub.docker.com/r/denji/nginx-boringssl/builds/bbnsvsbkhg493pky7tu2es9/